### PR TITLE
Allow webpack to watch files and rebuild on change

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ A Serverless Node Express lambda (NearestAtfFunction) for showing nearest ATF ce
 1. `npm run start:dev`
 1. Go to `http://localhost:3007/` on browser
 
+### Run and watch Locally
+
+As steps above but instead of `build:dev`
+- `npm run watch:dev`
+
+and in a separate terminal, run
+
+- `npm run start:dev`
+
+Note: only `.ts` files are being watched. Any changes to template `njk` files will not be watched so will not rebuilt.
 
 ## Debug Locally (VS Code only)
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lint": "eslint '*/**/*.ts' --quiet --fix",
     "test": "jest --coverage",
     "build:dev": "webpack-cli --config webpack.development.js",
+    "watch:dev": "webpack-cli --config webpack.development.watch.js",
     "build:prod": "webpack-cli --config webpack.production.js",
     "start:dev": "sam local start-api -p 3007 --docker-network hvt-network"
   },

--- a/webpack.development.watch.js
+++ b/webpack.development.watch.js
@@ -1,0 +1,8 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'development',
+  devtool: 'source-map',
+  watch: true
+});


### PR DESCRIPTION
## Description

- New npm command to watch files and rebuild on change
- Note, webpack watch only watches files it's resolved, so only TypeScript
files and not the template njk files
- Updated README with instructions how to run

Related issue: n/a


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
