### PR TITLE
BL-11913 Change filtering options to use radio buttons

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,8 +8,5 @@
         "alwaysTryTypes": true
       }
     }
-  },
-  "rules": {
-    "max-len": ["error", { "code": 120 }] // Set default max line length
   }
 }

--- a/src/controllers/index.controller.ts
+++ b/src/controllers/index.controller.ts
@@ -31,7 +31,6 @@ export const search = async (req: Request, res: Response, next: NextFunction): P
     const currentPage = pagination.getCurrentPageFromRequest(req, PAGINATION_MAX_NUMBER_OF_PAGES);
     const paginationOptions: PaginationOptions = { page: currentPage, limit: PAGINATION_ITEMS_PER_PAGE };
     const filters: ResultsFilters = getFiltersFromRequest(req);
-    // eslint-disable-next-line max-len
     const pagedResponse: PagedResponse<AuthorisedTestingFacility> = await geolocationService.nearest(req, postcode, paginationOptions, filters);
 
     if (pagedResponse.Items === undefined) {
@@ -46,6 +45,7 @@ export const search = async (req: Request, res: Response, next: NextFunction): P
       searchNormalised: postcodeUtils.toNormalised(postcode),
       data: pagedResponse.Items,
       filters: {
+        showAll: Object.keys(filters).length < 1,
         removeAtfsWithNoAvailability: filters.removeAtfsWithNoAvailability === 'true',
       },
       paginationSettings: {

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -28,5 +28,4 @@ const binaryMimeTypes = [
 ];
 const server = awsServerlessExpress.createServer(app, null, binaryMimeTypes);
 
-// eslint-disable-next-line max-len
 export const handler = (event: APIGatewayProxyEvent, context: Context): Server => awsServerlessExpress.proxy(server, event, context);

--- a/src/utils/filters.util.ts
+++ b/src/utils/filters.util.ts
@@ -13,6 +13,9 @@ export const getFiltersFromRequest = (req: Request): ResultsFilters => {
   if (postParamFilters && postParamFilters.includes('removeNoAvailability')) {
     resultsFilters.removeAtfsWithNoAvailability = 'true';
   }
+  if (postParamFilters && postParamFilters.includes('clearFilters')) {
+    return {};
+  }
 
   return resultsFilters;
 };

--- a/src/utils/request.util.ts
+++ b/src/utils/request.util.ts
@@ -1,7 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
 import { Request } from 'express';
 
-// eslint-disable-next-line max-len
 const getCorrelationId = (req: Request): Record<string, string> => ({ 'X-Correlation-Id': <string> req.app.locals.correlationId });
 
 const getHeaders = (req: Request) : Record<string, Record<string, string>> => ({ headers: getCorrelationId(req) });

--- a/src/utils/viewHelper.util.ts
+++ b/src/utils/viewHelper.util.ts
@@ -9,11 +9,8 @@ export const setUpNunjucks = (app: Express): Environment => {
     express: app,
   }).addGlobal('NODE_ENV', process.env.NODE_ENV)
     .addGlobal('getAsset', (name: string) => (process.env.CDN_URL || '/assets/') + name)
-    // eslint-disable-next-line max-len
     .addFilter('formatDate', (date: string) => format(utcToZonedTime(new Date(date), process.env.TIMEZONE), 'd MMMM yyyy'))
-    // eslint-disable-next-line max-len
     .addFilter('formatDateTime', (date: string) => format(utcToZonedTime(new Date(date), process.env.TIMEZONE), 'EEEE d MMMM yyyy \'at\' h:mmaaaaa\'m\''))
-    // eslint-disable-next-line max-len
     .addFilter('isDateUndefinedOrBeforeToday', (date: number | undefined) => ((date && isValid(parseISO(date.toString()))) ? utcToZonedTime(new Date(date), process.env.TIMEZONE) < utcToZonedTime(new Date(), process.env.TIMEZONE) : true))
     .addFilter('to1DP', (numeral: number): string => numeral.toFixed(1))
     .addFilter('wrapPhraseIntoLink', (text: string, phrases: string[], link: string, cssClass: string): string => {

--- a/src/views/search/results.njk
+++ b/src/views/search/results.njk
@@ -27,35 +27,45 @@
   </div>
   {% set filterUrl = "?postcode=" + search %}
   <form action={{filterUrl}} method="POST" id="filter-results-form">
-
     <div class="govuk-form-group dvsa-no-margin-bottom">
       <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend">
-          Show:
-        </legend>
-        <div class="govuk-radios govuk-radios govuk-radios--small govuk-radios--inline">
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="clear-filters-radio" name="filters" type="radio"
-                value="clearFilters" onchange="this.form.submit();"
-                {% if filters | length %}checked{% endif %}>
-              <label class="govuk-label govuk-radios__label" for="clear-filters-radio">
-                All
-              </label>
-            </div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="remove-no-availability-filter-radio" name="filters"
-                type="radio" onchange="this.form.submit();" value="removeNoAvailability"
-                {% if filters.removeAtfsWithNoAvailability %}checked{% endif %}>
-              <label class="govuk-label govuk-radios__label" for="remove-no-availability-filter-radio">
-                Centres with tests available
-              </label>
-            </div>
-        </div>
+        {{ govukRadios({
+          classes: "govuk-radios--small govuk-radios--inline",
+          name: "filters",
+          fieldset: {
+            legend: {
+              text: "Show:"
+            }
+          },
+          items: [
+            {
+              value: "clearFilters",
+              checked: filters.showAll,
+              text: "All",
+              id: "show-all-results-radio-button",
+              attributes: {
+                onchange: "this.form.submit();"
+              }
+            },
+            {
+              value: "removeNoAvailability",
+              checked: filters.removeAtfsWithNoAvailability,
+              text: "Centres with tests available",
+              id: "remove-no-availability-filter-radio-button",
+              attributes: {
+                onchange: "this.form.submit();"
+              }
+            }
+          ]
+        }) }}
       </fieldset>
     </div>
     <noscript>
       {{ govukButton({
-        text: "Filter"
+        text: "Filter",
+        attributes: {
+          id: "filter-results-button"
+        }
       }) }}
     </noscript>
   </form>

--- a/src/views/search/results.njk
+++ b/src/views/search/results.njk
@@ -1,7 +1,7 @@
 {% from "includes/atf/macro.njk" import renderAtf %}
 {% from "includes/pagination/macro.njk" import pagination %}
 {% from "govuk-frontend/govuk/components/details/macro.njk" import govukDetails %}
-{% from "govuk-frontend/govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk-frontend/govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk-frontend/govuk/components/button/macro.njk" import govukButton %}
 
 {% extends "layouts/layout.njk" %}
@@ -19,50 +19,46 @@
     Test centres near '{{ searchNormalised | escape }}'
     <p class="govuk-body-s"></p>
   </h1>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half govuk-hint">
-      {% set start = (paginationSettings.currentPage - 1) * paginationSettings.perPage + 1 %}
-      {% set end = start + paginationSettings.itemsCount - 1 %}
-      {% set total = paginationSettings.scannedItemsCount %}
-      Showing {{ start }} to {{ end }} of {{ total }} results
-    </div>
-    <div class="govuk-grid-column-one-half">
-      {% set filterUrl = "?postcode=" + search %}
-      <form action={{filterUrl}} method="POST" id="filter-results-form">
-        {{ govukCheckboxes({
-          name: "filters",
-          classes: "govuk-checkboxes--small",
-          fieldset: {
-            legend: {
-              text: "Filter the results"
-            }
-          },
-          items: [
-            {
-              id: "remove-no-availability-filter-checkbox",
-              value: "removeNoAvailability",
-              text: "Remove fully booked test centres",
-              checked: filters.removeAtfsWithNoAvailability
-            }
-          ]
-        }) }}
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Filter",
-            attributes: {
-              id: "filters-submit-button"
-            }
-          }) }}
-
-          {% set clearFiltersLink = "?postcode=" + search %}
-          <a class="govuk-link govuk-link--no-visited-state govuk-!-padding-1"
-            href={{clearFiltersLink}} id="clear-filters-link">
-            Clear filters
-          </a>
-        </div>
-      </form>
-    </div>
+  <div class="govuk-hint">
+    {% set start = (paginationSettings.currentPage - 1) * paginationSettings.perPage + 1 %}
+    {% set end = start + paginationSettings.itemsCount - 1 %}
+    {% set total = paginationSettings.scannedItemsCount %}
+    Showing {{ start }} to {{ end }} of {{ total }} results
   </div>
+  {% set filterUrl = "?postcode=" + search %}
+  <form action={{filterUrl}} method="POST" id="filter-results-form">
+
+    <div class="govuk-form-group dvsa-no-margin-bottom">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend">
+          Show:
+        </legend>
+        <div class="govuk-radios govuk-radios govuk-radios--small govuk-radios--inline">
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="clear-filters-radio" name="filters" type="radio"
+                value="clearFilters" onchange="this.form.submit();"
+                {% if filters | length %}checked{% endif %}>
+              <label class="govuk-label govuk-radios__label" for="clear-filters-radio">
+                All
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="remove-no-availability-filter-radio" name="filters"
+                type="radio" onchange="this.form.submit();" value="removeNoAvailability"
+                {% if filters.removeAtfsWithNoAvailability %}checked{% endif %}>
+              <label class="govuk-label govuk-radios__label" for="remove-no-availability-filter-radio">
+                Centres with tests available
+              </label>
+            </div>
+        </div>
+      </fieldset>
+    </div>
+    <noscript>
+      {{ govukButton({
+        text: "Filter"
+      }) }}
+    </noscript>
+  </form>
 
   <div class="search-results">
     <hr>

--- a/tests/controllers/index.controller.test.ts
+++ b/tests/controllers/index.controller.test.ts
@@ -103,6 +103,7 @@ describe('Test search.controller', () => {
               },
               filters: {
                 removeAtfsWithNoAvailability: false,
+                showAll: true,
               },
             },
           );
@@ -137,6 +138,7 @@ describe('Test search.controller', () => {
               },
               filters: {
                 removeAtfsWithNoAvailability: false,
+                showAll: true,
               },
             },
           );
@@ -171,6 +173,7 @@ describe('Test search.controller', () => {
               },
               filters: {
                 removeAtfsWithNoAvailability: false,
+                showAll: true,
               },
             },
           );
@@ -205,6 +208,7 @@ describe('Test search.controller', () => {
               },
               filters: {
                 removeAtfsWithNoAvailability: false,
+                showAll: true,
               },
             },
           );
@@ -237,6 +241,7 @@ describe('Test search.controller', () => {
               },
               filters: {
                 removeAtfsWithNoAvailability: false,
+                showAll: true,
               },
             },
           );
@@ -269,6 +274,7 @@ describe('Test search.controller', () => {
               },
               filters: {
                 removeAtfsWithNoAvailability: true,
+                showAll: false,
               },
             },
           );
@@ -300,6 +306,7 @@ describe('Test search.controller', () => {
               },
               filters: {
                 removeAtfsWithNoAvailability: true,
+                showAll: false,
               },
             },
           );
@@ -308,6 +315,101 @@ describe('Test search.controller', () => {
             postcodeNormalisedStripped,
             { page: 1, limit: perPage },
             { removeAtfsWithNoAvailability: 'true' },
+          );
+        });
+
+        it('should set the showAll filter property to true in the view context when present in the request body', async () => {
+          reqMock.query = { postcode, page: '-1' };
+          reqMock.body = { filters: 'clearFilters' };
+
+          await search(reqMock, resMock, nextMock);
+
+          expect(renderSpy).toHaveBeenCalledWith(
+            'search/results',
+            {
+              search: postcodeNormalisedStripped,
+              searchNormalised: postcodeNormalised,
+              data: atfs,
+              paginationSettings: {
+                currentPage: 1,
+                perPage,
+                itemsCount: perPage,
+                scannedItemsCount: atfsNumber,
+              },
+              filters: {
+                removeAtfsWithNoAvailability: false,
+                showAll: true,
+              },
+            },
+          );
+          expect(geolocationService.nearest).toHaveBeenCalledWith(
+            reqMock,
+            postcodeNormalisedStripped,
+            { page: 1, limit: perPage },
+            {},
+          );
+        });
+
+        it('should set the showAll filter property to true in the view context even if other filters are present', async () => {
+          reqMock.query = { postcode, page: '-1' };
+          reqMock.body = { filters: ['clearFilters', 'removeNoAvailability'] };
+
+          await search(reqMock, resMock, nextMock);
+
+          expect(renderSpy).toHaveBeenCalledWith(
+            'search/results',
+            {
+              search: postcodeNormalisedStripped,
+              searchNormalised: postcodeNormalised,
+              data: atfs,
+              paginationSettings: {
+                currentPage: 1,
+                perPage,
+                itemsCount: perPage,
+                scannedItemsCount: atfsNumber,
+              },
+              filters: {
+                removeAtfsWithNoAvailability: false,
+                showAll: true,
+              },
+            },
+          );
+          expect(geolocationService.nearest).toHaveBeenCalledWith(
+            reqMock,
+            postcodeNormalisedStripped,
+            { page: 1, limit: perPage },
+            {},
+          );
+        });
+
+        it('should set the showAll filter property to true on first load', async () => {
+          reqMock.query = { postcode, page: '1' };
+
+          await search(reqMock, resMock, nextMock);
+
+          expect(renderSpy).toHaveBeenCalledWith(
+            'search/results',
+            {
+              search: postcodeNormalisedStripped,
+              searchNormalised: postcodeNormalised,
+              data: atfs,
+              paginationSettings: {
+                currentPage: 1,
+                perPage,
+                itemsCount: perPage,
+                scannedItemsCount: atfsNumber,
+              },
+              filters: {
+                removeAtfsWithNoAvailability: false,
+                showAll: true,
+              },
+            },
+          );
+          expect(geolocationService.nearest).toHaveBeenCalledWith(
+            reqMock,
+            postcodeNormalisedStripped,
+            { page: 1, limit: perPage },
+            {},
           );
         });
 
@@ -330,6 +432,7 @@ describe('Test search.controller', () => {
               },
               filters: {
                 removeAtfsWithNoAvailability: false,
+                showAll: true,
               },
             },
           );
@@ -360,6 +463,7 @@ describe('Test search.controller', () => {
               },
               filters: {
                 removeAtfsWithNoAvailability: false,
+                showAll: true,
               },
             },
           );
@@ -406,6 +510,7 @@ describe('Test search.controller', () => {
               },
               filters: {
                 removeAtfsWithNoAvailability: false,
+                showAll: true,
               },
             },
           );

--- a/tests/utils/filters.util.test.ts
+++ b/tests/utils/filters.util.test.ts
@@ -78,5 +78,21 @@ describe('Filters utility tests', () => {
       const result = getFiltersFromRequest(requestMock);
       expect(result).toEqual({});
     });
+
+    test('should return an empty object if clearFilters is included in filters list', () => {
+      requestMock.body = {
+        filters: ['removeNoAvailability', 'clearFilters', 'otherFilter', 'anotherFilter'],
+      };
+      const result = getFiltersFromRequest(requestMock);
+      expect(result).toEqual({});
+    });
+
+    test('should return an empty object if clearFilters is the only filter present', () => {
+      requestMock.body = {
+        filters: 'clearFilters',
+      };
+      const result = getFiltersFromRequest(requestMock);
+      expect(result).toEqual({});
+    });
   });
 });

--- a/tests/utils/filters.util.test.ts
+++ b/tests/utils/filters.util.test.ts
@@ -56,7 +56,6 @@ describe('Filters utility tests', () => {
       expect(result).toEqual({});
     });
 
-    // eslint-disable-next-line max-len
     test('should add removeAtfsWithNoAvailability if req body filters is an array and includes removeNoAvailability', () => {
       requestMock.body = {
         filters: ['otherFilter', 'removeNoAvailability'],
@@ -65,7 +64,6 @@ describe('Filters utility tests', () => {
       expect(result).toEqual(resultsFiltersWithNoAvailability);
     });
 
-    // eslint-disable-next-line max-len
     test('should not add removeAtfsWithNoAvailability if req body filters is an array and does not include removeNoAvailability', () => {
       requestMock.body = {
         filters: ['otherFilter', 'anotherFilter'],

--- a/tests/utils/viewHelper.util.test.ts
+++ b/tests/utils/viewHelper.util.test.ts
@@ -47,7 +47,6 @@ describe('Test viewHelper.util', () => {
 
   describe('isDateUndefinedOrBeforeToday filter function', () => {
     const undefinedOrInvalidDates = [undefined, false, true, null, '', 0, 0o0, NaN, new Date('')];
-    // eslint-disable-next-line max-len
     const isDateUndefinedOrBeforeToday: IsDateUndefinedOrBeforeTodayFunctionType = <IsDateUndefinedOrBeforeTodayFunctionType> nunjucks.getFilter('isDateUndefinedOrBeforeToday');
 
     it('should return true for a date that occurs before today\'s date', () => {
@@ -58,10 +57,11 @@ describe('Test viewHelper.util', () => {
       expect(isDateUndefinedOrBeforeToday(yesterday)).toBe(true);
     });
 
-    it('should return false for a date that occurs on today\'s date', () => {
-      const today: string = new Date().toISOString();
+    it('should return true for a time in the past that occurs on today\'s date', () => {
+      const oneHourInMs = 1000 * 60 * 60;
+      const dateOneHourAgo = new Date(Date.now() - oneHourInMs).toISOString();
 
-      expect(isDateUndefinedOrBeforeToday(today)).toBe(false);
+      expect(isDateUndefinedOrBeforeToday(dateOneHourAgo)).toBe(true);
     });
 
     it('should return false for a date that occurs after today\'s date', () => {
@@ -80,7 +80,6 @@ describe('Test viewHelper.util', () => {
   });
 
   describe('wrapPhraseIntoLink filter function', () => {
-    // eslint-disable-next-line max-len
     const wrapPhraseIntoLink: WrapPhraseIntoLinkFunctionType = <WrapPhraseIntoLinkFunctionType> nunjucks.getFilter('wrapPhraseIntoLink');
 
     const phrases: string[] = ['foo', 'bar', 'baz'];
@@ -100,7 +99,6 @@ describe('Test viewHelper.util', () => {
 
       const result: string = wrapPhraseIntoLink(text, phrases, link, cssClasses);
 
-      // eslint-disable-next-line max-len
       expect(result).toBe(`lorem ipsum <a href="${link}" class="${cssClasses}" target="_blank">foo</a> <a href="${link}" class="${cssClasses}" target="_blank">bar</a>`);
     });
 


### PR DESCRIPTION
## Description

Update filtering by availability options to use radio buttons rather than checkboxes.
The radio buttons should instantly trigger form submission on change and not require the use of a submit button.
However, in the case that JS is disabled, a submit button should be present to allow submission. 

Related issue: https://jira.dvsacloud.uk/browse/BL-11913


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
