### PR TITLE
Optionally pass in variable for commit to name zip and remove .env file in prod builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,5 +104,5 @@ dist
 # TernJS port file
 .tern-port
 
-# Mac files
-.DS_Store
+# mac
+.DS_STORE

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -35,7 +35,6 @@ module.exports = {
     new CopyPlugin({
       patterns: [
         { from: './simple-proxy-api.yml', to: '.aws-sam/build/simple-proxy-api.yml' },
-        { from: './.env', to: `.aws-sam/build/${lambdaName}/` },
         { from: './src/views', to: `.aws-sam/build/${lambdaName}/views` },
         { from: './node_modules/govuk-frontend', to: `.aws-sam/build/${lambdaName}/views/govuk-frontend` },
         { from: './node_modules/govuk-frontend/govuk/assets', to: `.aws-sam/build/${lambdaName}/public/assets` },

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -1,7 +1,16 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
+const CopyPlugin = require('copy-webpack-plugin');
+const lambdaName = "NearestAtfFunction"; // must correspond to lambda name in template.yml
 
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'source-map',
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        { from: './.env', to: `.aws-sam/build/${lambdaName}/` },
+      ],
+    }),
+  ]
 });

--- a/webpack.development.watch.js
+++ b/webpack.development.watch.js
@@ -1,8 +1,6 @@
 const { merge } = require('webpack-merge');
-const common = require('./webpack.common.js');
+const development = require('./webpack.development.js');
 
-module.exports = merge(common, {
-  mode: 'development',
-  devtool: 'source-map',
-  watch: true
+module.exports = merge(development, {
+  watch: true,
 });

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -9,7 +9,8 @@ const MinifyBundledPlugin = require('minify-bundled-webpack-plugin');
 
 const LAMBDA_NAME = 'NearestAtfFunction';
 const OUTPUT_FOLDER = './dist'
-const BUILD_VERSION = branchName().replace("/","-");
+const REPO_NAME = 'hvt-nearest-atf';
+const BRANCH_NAME = branchName().replace("/","-");
 
 class BundlePlugin {
   constructor(params) {
@@ -56,7 +57,10 @@ class BundlePlugin {
   }
 };
 
-module.exports = merge(common, {
+
+module.exports = env => {
+ let commit = env ? env.commit ? env.commit : 'local' : 'local' ;
+ return merge(common, {
   mode: 'production',
   plugins: [
     new MinifyBundledPlugin({
@@ -67,14 +71,14 @@ module.exports = merge(common, {
         {
           inputPath: `.aws-sam/build/${LAMBDA_NAME}`,
           outputPath: `${OUTPUT_FOLDER}`,
-          outputName: `HVT-${LAMBDA_NAME}-${BUILD_VERSION}`,
+          outputName: `${REPO_NAME}-${BRANCH_NAME}-${commit}`,
           ignore: ['public']
         }
       ],
       assets: [
         {
           inputPath: `./.aws-sam/build/${LAMBDA_NAME}/public`,
-          outputPath: `${OUTPUT_FOLDER}/${LAMBDA_NAME}-cloudfront-assets-${BUILD_VERSION}`,
+          outputPath: `${OUTPUT_FOLDER}/${REPO_NAME}-cloudfront-assets-${BRANCH_NAME}-${commit}`,
         }
       ]
     }),
@@ -84,4 +88,5 @@ module.exports = merge(common, {
       new CssMinimizerPlugin(),
     ],
   },
-});
+})
+};


### PR DESCRIPTION
## Description
- Can now optionally pass in `env.commit=<something>` when building in the pipeline
so the zip file is named correctly through build config files, not through
the Jenkinsfile scripts
- Pipeline can now call build command:
`npm run build:prod -- --env.commit=<commit>`
- Also remove the .env file from prod builds as this file is only required
for dev builds and should not be included
- Ticket #BL-11943

Related issue: BL-11943

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
